### PR TITLE
Validate bond slaves have no mac duplicates

### DIFF
--- a/bond/util/validation.go
+++ b/bond/util/validation.go
@@ -1,0 +1,65 @@
+package util
+
+import (
+	"crypto/rand"
+	"fmt"
+	"github.com/vishvananda/netlink"
+)
+
+func HandleMacDuplicates(linkObjectsToBond []netlink.Link, netNsHandle *netlink.Handle) error {
+	macsInUse := []string{}
+	var err error
+	for _, link := range linkObjectsToBond {
+		linkMac := link.Attrs().HardwareAddr.String()
+		if isMacDuplicated(linkMac, macsInUse) {
+			linkMac, err = updateDuplicateMac(link, netNsHandle, macsInUse)
+			if err != nil {
+				return err
+			}
+		}
+		macsInUse = append(macsInUse, linkMac)
+	}
+	return nil
+}
+
+func isMacDuplicated(mac string, macsInUse []string) bool {
+	for _, usedMac := range macsInUse {
+		if mac == usedMac {
+			return true
+		}
+	}
+	return false
+}
+
+func updateDuplicateMac(link netlink.Link, netNsHandle *netlink.Handle, macsInUse []string) (string, error) {
+	newMac, err := generateUnusedMac(macsInUse)
+	if err != nil {
+		return "", err
+	}
+	err = netNsHandle.LinkSetHardwareAddr(link, []byte(newMac))
+	if err != nil {
+		return "newMac", nil
+	}
+	return newMac, nil
+}
+
+func generateUnusedMac(macsInUse []string) (string, error) {
+	var newMac string
+	var err error
+	for duplicated := true; duplicated; duplicated = isMacDuplicated(newMac, macsInUse) {
+		newMac, err = randomMac()
+		if err != nil {
+			return "", err
+		}
+	}
+	return newMac, nil
+}
+
+func randomMac() (string, error) {
+	buf := make([]byte, 5)
+	_, err := rand.Read(buf)
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("%02x:%02x:%02x:%02x:%02x:%02x\n", byte(2), buf[0], buf[1], buf[2], buf[3], buf[4]), nil
+}

--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/nxadm/tail v1.4.8 // indirect
 	github.com/safchain/ethtool v0.0.0-20210803160452-9aa261dae9b1 // indirect
 	golang.org/x/net v0.0.0-20210428140749-89ef3d95e781 // indirect
+	golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e // indirect
 	golang.org/x/text v0.3.6 // indirect
 	gopkg.in/tomb.v1 v1.0.0-20141024135613-dd632973f1e7 // indirect
 	gopkg.in/yaml.v2 v2.4.0 // indirect

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -1,5 +1,5 @@
 # github.com/containernetworking/cni v1.0.1
-## explicit
+## explicit; go 1.14
 github.com/containernetworking/cni/pkg/invoke
 github.com/containernetworking/cni/pkg/skel
 github.com/containernetworking/cni/pkg/types
@@ -78,7 +78,10 @@ github.com/vishvananda/netns
 golang.org/x/net/html
 golang.org/x/net/html/atom
 golang.org/x/net/html/charset
+# golang.org/x/sys v0.0.0-20210809222454-d867a43fc93e
 ## explicit; go 1.17
+golang.org/x/sys/internal/unsafeheader
+golang.org/x/sys/unix
 # golang.org/x/text v0.3.6
 ## explicit; go 1.11
 golang.org/x/text/encoding


### PR DESCRIPTION
This PR ensures that bond creation does not fail when slaves with duplicate macs are to be assigned to the bond.
Such a situation can arise when balance-alb bonds are created multiple times over. When such a bond is removed, the slaves are given back to the pool of free interfaces (for example vf's in case of sriov). If such interfaces with duplicate macs are used for another bond in balance-alb mode, the bond creation will fail due to duplicate macs.
In this PR we are detecting such a situation, and reset the duplicate mac to a random one on one of the conflicting interfaces.