### PR TITLE
Handle duplicate macs on bond delete

### DIFF
--- a/bond/bond.go
+++ b/bond/bond.go
@@ -455,6 +455,10 @@ func cmdDel(args *skel.CmdArgs) error {
 		return fmt.Errorf("Failed to deattached links from bond, error: %+v", err)
 	}
 
+	if err = util.HandleMacDuplicates(linkObjectsToDeattach, netNsHandle); err != nil {
+		return fmt.Errorf("Failed to validate deattached links macs, error: %+v", err)
+	}
+
 	err = netNsHandle.LinkDel(linkObjToDel)
 	if err != nil {
 		return fmt.Errorf("Failed to delete bonded link (%+v), error: %+v", linkObjToDel.Attrs().Name, err)


### PR DESCRIPTION
Slave mac addresses could be set to be duplicated when part of a bond. Currently when a pod is deleted, the plugin just gives these slaves back to the pool with macs duplicated. This PR tried to remedy this, and randomizes the mac if duplicate macs are detected on the slaves being returned.
