### PR TITLE
Enable race detection in unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -10,4 +10,4 @@ build-bin:
 	./build.sh
 
 test: build-bin # Tests need sudo due to network interfaces creation
-	sudo -E bash -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test ./bond/"
+	sudo -E bash -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test -race ./bond/"


### PR DESCRIPTION
This pull request enables race detection in unit tests by modifying the Makefile. The test configuration is updated to include the '-race' flag, allowing thorough race detection during testing. 

Race detection can help identifying potential data race conditions, which can lead to hard-to-debug issues in concurrent code. By enabling race detection in our unit tests, we can detect and address these race conditions, ensuring the reliability and stability of our code. (for further reference view: [race_detector](https://go.dev/doc/articles/race_detector)
