### PR TITLE
Add Coveralls step in GH actions

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -51,3 +51,25 @@ jobs:
 
       - name: Test
         run: make test
+
+  coverage:
+    runs-on: ubuntu-latest
+    needs: build
+    name: coverage
+    steps:
+      - name: Set up Go
+        uses: actions/setup-go@v1
+        with:
+          go-version: ${{ env.GO_VERSION }}
+
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v2
+
+      - name: Go test with coverage
+        run: sudo make test-coverage # sudo needed for network interfaces creation
+
+      - name: Coveralls
+        uses: coverallsapp/github-action@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          path-to-lcov: test/coverage/lcov.info

--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,3 @@
 bin/
+/test/coverage*
+/.gopath/*

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,40 @@
+
+# Go environment:
+GOPATH=$(CURDIR)/.gopath
+GOBIN=$(CURDIR)/bin
+
+export GOPATH
+export GOBIN
+
+# Go tools:
+GOCOVXML = $(GOBIN)/gocov-xml
+GOCOVMERGE = $(GOBIN)/gocovmerge
+GOCOV = $(GOBIN)/gocov
+GCOV2LCOV = $(GOBIN)/gcov2lcov
+
+# Package info
+PACKAGE=bond-cni
+ORG_PATH=github.com/k8snetworkplumbingwg
+
+# Build info
+REPO_PATH=$(ORG_PATH)/$(PACKAGE)
+BASE=$(GOPATH)/src/$(REPO_PATH)
+PKGS = $(or $(PKG),$(shell cd $(BASE) && env GOPATH=$(GOPATH) go list ./... | grep -v "^$(PACKAGE)/vendor/"))
+
+# Test artifacts and settings:
+TESTPKGS = $(shell env GOPATH=$(GOPATH) go list -f '{{ if or .TestGoFiles .XTestGoFiles }}{{ .ImportPath }}{{ end }}' $(PKGS))
+COVERAGE_MODE = atomic
+COVERAGE_DIR = $(CURDIR)/test/coverage
+COVERAGE_PROFILE = $(COVERAGE_DIR)/profile.out
+COVERAGE_XML = $(COVERAGE_DIR)/coverage.xml
+COVERAGE_HTML = $(COVERAGE_DIR)/index.html
+
+
+$(BASE): ; $(info  Setting GOPATH...)
+	@mkdir -p $(dir $@)
+	@ln -sf $(CURDIR) $@
+
+
 deps-update:
 	go mod tidy && \
 	go mod vendor
@@ -11,3 +48,39 @@ build-bin:
 
 test: build-bin # Tests need sudo due to network interfaces creation
 	sudo -E bash -c "umask 0; PATH=${GOPATH}/bin:$(pwd)/bin:${PATH} go test -race ./bond/"
+
+
+# tool that takes the results from multiple go test -coverprofile runs and merges them into one profile
+$(GOCOVMERGE): | $(BASE) ; $(info  building gocovmerge...)
+	go install github.com/wadey/gocovmerge@latest
+
+# Convert golang test coverage to lcov format (which can be uploaded to coveralls).
+$(GCOV2LCOV): | $(BASE) ; $(info  building gcov2lcov...)
+	go install github.com/jandelgado/gcov2lcov@latest
+
+# A tool to generate Go coverage in XML report
+$(GOCOVXML): | $(BASE) ; $(info  building gocov-xml...)
+	go install github.com/AlekSi/gocov-xml@latest
+
+#Coverage reporting tool
+$(GOCOV): | $(BASE) ; $(info  building gocov...)
+	go install github.com/axw/gocov/gocov@v1.1.0
+
+
+.PHONY: test-coverage test-coverage-tools
+test-coverage-tools: | $(GOCOVMERGE) $(GOCOV) $(GOCOVXML) $(GCOV2LCOV)
+test-coverage: COVERAGE_DIR := $(CURDIR)/test/coverage
+test-coverage: test-coverage-tools | $(BASE) ; $(info  Running coverage tests...) @ ## Run coverage tests
+	mkdir -p $(COVERAGE_DIR)/coverage
+	cd $(BASE) && for pkg in $(TESTPKGS); do \
+		go test \
+			-coverpkg=$$(go list -f '{{ join .Deps "\n" }}' $$pkg | \
+					grep '^$(PACKAGE)/' | grep -v '^$(PACKAGE)/vendor/' | \
+					tr '\n' ',')$$pkg \
+			-covermode=$(COVERAGE_MODE) \
+			-coverprofile="$(COVERAGE_DIR)/coverage/`echo $$pkg | tr "/" "-"`.cover" $$pkg ;\
+	done
+	$(GOCOVMERGE) $(COVERAGE_DIR)/coverage/*.cover > $(COVERAGE_PROFILE)
+	go tool cover -html=$(COVERAGE_PROFILE) -o $(COVERAGE_HTML)
+	$(GOCOV) convert $(COVERAGE_PROFILE) | $(GOCOVXML) > $(COVERAGE_XML)
+	$(GCOV2LCOV) -infile $(COVERAGE_PROFILE) -outfile $(COVERAGE_DIR)/lcov.info

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # Bond CNI plugin
 
+[![Coverage Status](https://coveralls.io/repos/github/k8snetworkplumbingwg/bond-cni/badge.svg?branch=master)](https://coveralls.io/github/k8snetworkplumbingwg/bond-cni?branch=master)
+
 - Bonding provides a method for aggregating multiple network interfaces into a single logical &quot;bonded&quot; interface.
 - According to the 802.3ad specification, Linux Bonding drivers provides various flavours of bonded interfaces depending on the mode (bonding policies), such as round robin, active aggregation
 - When Bond CNI is configured as a standalone plugin, interfaces are obtained from the host network namespace. With these physical interfaces a bonded interface is created in the container network namespace.


### PR DESCRIPTION
The goal of this PR is to add coverage testing by adding the test-coverage Target to the Makefile. This target sets up the coverage directory, executes coverage tests, and generates LCOV information that can be read by the [Coveralls action](https://github.com/marketplace/actions/coveralls-github-action).
Additionally, a Coveralls badge is added to the README.md file.