### PR TITLE
Increase Bond CNI Coverage

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -29,7 +29,7 @@ COVERAGE_PROFILE = $(COVERAGE_DIR)/profile.out
 COVERAGE_XML = $(COVERAGE_DIR)/coverage.xml
 COVERAGE_HTML = $(COVERAGE_DIR)/index.html
 
-
+.PHONY: $(BASE)
 $(BASE): ; $(info  Setting GOPATH...)
 	@mkdir -p $(dir $@)
 	@ln -sf $(CURDIR) $@

--- a/bond/bond_test.go
+++ b/bond/bond_test.go
@@ -16,6 +16,8 @@ package main
 
 import (
 	"fmt"
+	"strconv"
+
 	"github.com/containernetworking/cni/pkg/skel"
 	"github.com/containernetworking/cni/pkg/types"
 	types020 "github.com/containernetworking/cni/pkg/types/020"
@@ -39,7 +41,7 @@ const (
 			"cniVersion": "%s",
 			"mode": "%s",
 			"failOverMac": 1,
-			"linksInContainer": true,
+			"linksInContainer": %s,
 			"miimon": "100",
 			"mtu": 1400,
 			"links": [
@@ -55,267 +57,331 @@ var Slaves = []string{Slave1, Slave2}
 
 var _ = Describe("bond plugin", func() {
 	var podNS ns.NetNS
-
-	BeforeEach(func() {
-		var err error
-		podNS, err = testutils.NewNS()
-		Expect(err).NotTo(HaveOccurred())
-
-		for _, ifName := range Slaves {
-			err = podNS.Do(func(ns.NetNS) error {
-				defer GinkgoRecover()
-				err = netlink.LinkAdd(&netlink.Dummy{
-					LinkAttrs: netlink.LinkAttrs{
-						Name: ifName,
-					},
-				})
-				Expect(err).NotTo(HaveOccurred())
-				_, err := netlink.LinkByName(ifName)
-				Expect(err).NotTo(HaveOccurred())
-				return nil
-			})
-		}
-		Expect(err).NotTo(HaveOccurred())
-	})
+	var initNS ns.NetNS
+	var args *skel.CmdArgs
+	var linksInContainer bool
+	var linkAttrs = []netlink.LinkAttrs{
+		{Name: Slave1},
+		{Name: Slave2},
+	}
 
 	AfterEach(func() {
 		Expect(podNS.Close()).To(Succeed())
 		Expect(testutils.UnmountNS(podNS)).To(Succeed())
 	})
 
-	It("verifies a plugin is added and deleted correctly", func() {
-		args := &skel.CmdArgs{
-			ContainerID: "dummy",
-			Netns:       podNS.Path(),
-			IfName:      IfName,
-			StdinData:   []byte(fmt.Sprintf(Config, "0.3.1", ActiveBackupMode)),
-		}
-
-		By("creating the plugin")
-		r, _, err := testutils.CmdAddWithArgs(args, func() error {
-			return cmdAdd(args)
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("validationg the returned result is correct")
-		checkAddReturnResult(&r, IfName)
-
-		err = podNS.Do(func(ns.NetNS) error {
-			defer GinkgoRecover()
-			By("validating the bond interface is configured correctly")
-			link, err := netlink.LinkByName(IfName)
+	When("links are in container`s network namespace at initial state (meaning linksInContainer is true)", func() {
+		BeforeEach(func() {
+			var err error
+			linksInContainer = true
+			podNS, err = testutils.NewNS()
 			Expect(err).NotTo(HaveOccurred())
-			bond := link.(*netlink.Bond)
-			Expect(bond.Attrs().MTU).To(Equal(1400))
-			Expect(bond.Mode.String()).To(Equal(ActiveBackupMode))
-			Expect(bond.Miimon).To(Equal(100))
-
-			By("validating the bond slaves are configured correctly")
-			for _, slaveName := range Slaves {
-				slave, err := netlink.LinkByName(slaveName)
-				Expect(err).NotTo(HaveOccurred())
-				Expect(slave.Attrs().Slave).NotTo(BeNil())
-				Expect(slave.Attrs().MasterIndex).To(Equal(bond.Attrs().Index))
+			addLinksInNS(podNS, linkAttrs)
+			args = &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       podNS.Path(),
+				IfName:      IfName,
+				StdinData:   []byte(fmt.Sprintf(Config, "0.3.1", ActiveBackupMode, strconv.FormatBool(true))),
 			}
-			return nil
 		})
-		Expect(err).NotTo(HaveOccurred())
 
-		By("validating the bond interface is deleted correctly")
-		err = testutils.CmdDel(podNS.Path(),
-			args.ContainerID, "", func() error { return cmdDel(args) })
-		Expect(err).NotTo(HaveOccurred())
+		It("verifies a plugin is added and deleted correctly", func() {
+			By("creating the plugin")
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
 
-		err = podNS.Do(func(ns.NetNS) error {
-			defer GinkgoRecover()
-			_, err = netlink.LinkByName(IfName)
-			Expect(err).To(HaveOccurred())
-			return nil
+			By("validationg the returned result is correct")
+			checkAddReturnResult(&r, IfName)
+
+			err = podNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				By("validating the bond interface is configured correctly")
+				link, err := netlink.LinkByName(IfName)
+				Expect(err).NotTo(HaveOccurred())
+				bond := link.(*netlink.Bond)
+				Expect(bond.Attrs().MTU).To(Equal(1400))
+				Expect(bond.Mode.String()).To(Equal(ActiveBackupMode))
+				Expect(bond.Miimon).To(Equal(100))
+
+				By("validating the bond slaves are configured correctly")
+				for _, slaveName := range Slaves {
+					slave, err := netlink.LinkByName(slaveName)
+					Expect(err).NotTo(HaveOccurred())
+					Expect(slave.Attrs().Slave).NotTo(BeNil())
+					Expect(slave.Attrs().MasterIndex).To(Equal(bond.Attrs().Index))
+				}
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("validating the bond interface is deleted correctly")
+			err = testutils.CmdDel(podNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			err = podNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				_, err = netlink.LinkByName(IfName)
+				Expect(err).To(HaveOccurred())
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
 		})
-		Expect(err).NotTo(HaveOccurred())
+
+		It("verifies the plugin handles multiple del commands", func() {
+			By("adding a bond interface")
+			_, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("deleting the bond interface")
+			err = testutils.CmdDel(podNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			By("deleting again the bond interface")
+			err = testutils.CmdDel(podNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		It("verifies the del command does not fail when a device (in container) assigned to the bond has been deleted", func() {
+			By("adding a bond interface")
+			_, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = podNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				By("deleting a slave interface")
+				slave, err := netlink.LinkByName(Slave1)
+				Expect(err).NotTo(HaveOccurred())
+				err = netlink.LinkDel(slave)
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+
+			Expect(err).NotTo(HaveOccurred())
+
+			By("deleting the bond interface")
+			err = testutils.CmdDel(podNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+		})
+
+		DescribeTable("verifies the plugin returns correct results for supported tested versions", func(version string) {
+
+			args.StdinData = []byte(fmt.Sprintf(Config, version, ActiveBackupMode, strconv.FormatBool(linksInContainer)))
+
+			By(fmt.Sprintf("creating the plugin with config in version %s", version))
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+			By(fmt.Sprintf("expecting the result version to be %s", version))
+			Expect(r.Version()).To(Equal(version))
+			checkAddReturnResult(&r, IfName)
+
+			By("deleting plugin")
+			err = testutils.CmdDel(podNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+		},
+			Entry("When Version is 0.3.0", "0.3.0"),
+			Entry("When Version is 0.3.1", "0.3.1"),
+			Entry("When Version is 0.4.0", "0.4.0"),
+			Entry("When Version is 1.0.0", "1.0.0"),
+			Entry("When Version is 0.2.0", "0.2.0"),
+			Entry("When Version is 0.1.0", "0.1.0"),
+		)
+
+		It("verifies the plugin copes with duplicated macs in balance-tlb mode", func() {
+			args.StdinData = []byte(fmt.Sprintf(Config, "0.3.1", BalanceTlbMode, strconv.FormatBool(linksInContainer)))
+
+			err := podNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+
+				slave1, err := netlink.LinkByName(Slave1)
+				Expect(err).NotTo(HaveOccurred())
+
+				slave2, err := netlink.LinkByName(Slave2)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = netlink.LinkSetHardwareAddr(slave2, slave1.Attrs().HardwareAddr)
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("creating the plugin")
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the bond was created")
+			checkAddReturnResult(&r, IfName)
+
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		It("verifies the plugin handles duplicated macs on delete", func() {
+			var slave1, slave2 netlink.Link
+			var err error
+
+			err = podNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				slave1, err = netlink.LinkByName(Slave1)
+				Expect(err).NotTo(HaveOccurred())
+
+				slave2, err = netlink.LinkByName(Slave2)
+				Expect(err).NotTo(HaveOccurred())
+
+				err = netlink.LinkSetHardwareAddr(slave2, slave1.Attrs().HardwareAddr)
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+
+			By("creating the plugin")
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			By("checking the bond was created")
+			checkAddReturnResult(&r, IfName)
+
+			err = podNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				By("duplicating the macs on the slaves")
+				err = netlink.LinkSetHardwareAddr(slave2, slave1.Attrs().HardwareAddr)
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
+			By("deleting the plugin")
+			err = testutils.CmdDel(podNS.Path(),
+				args.ContainerID, "", func() error { return cmdDel(args) })
+			Expect(err).NotTo(HaveOccurred())
+
+			err = podNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				By("validating the macs are not duplicated")
+				slave1, err = netlink.LinkByName(Slave1)
+				Expect(err).NotTo(HaveOccurred())
+				slave2, err = netlink.LinkByName(Slave2)
+				Expect(err).NotTo(HaveOccurred())
+				Expect(slave1.Attrs().HardwareAddr.String()).NotTo(Equal(slave2.Attrs().HardwareAddr.String()))
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		})
 	})
-
-	It("verifies the plugin handles multiple del commands", func() {
-		args := &skel.CmdArgs{
-			ContainerID: "dummy",
-			Netns:       podNS.Path(),
-			IfName:      IfName,
-			StdinData:   []byte(fmt.Sprintf(Config, "1.0.0", ActiveBackupMode)),
-		}
-
-		By("adding a bond interface")
-		_, _, err := testutils.CmdAddWithArgs(args, func() error {
-			return cmdAdd(args)
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("deleting the bond interface")
-		err = testutils.CmdDel(podNS.Path(),
-			args.ContainerID, "", func() error { return cmdDel(args) })
-		Expect(err).NotTo(HaveOccurred())
-
-		By("deleting again the bond interface")
-		err = testutils.CmdDel(podNS.Path(),
-			args.ContainerID, "", func() error { return cmdDel(args) })
-		Expect(err).NotTo(HaveOccurred())
-
-	})
-
-	It("verifies the del command does not fail when a device (in container) assigned to the bond has been deleted", func() {
-		args := &skel.CmdArgs{
-			ContainerID: "dummy",
-			Netns:       podNS.Path(),
-			IfName:      IfName,
-			StdinData:   []byte(fmt.Sprintf(Config, "1.0.0", ActiveBackupMode)),
-		}
-
-		By("adding a bond interface")
-		_, _, err := testutils.CmdAddWithArgs(args, func() error {
-			return cmdAdd(args)
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		err = podNS.Do(func(ns.NetNS) error {
-			defer GinkgoRecover()
-
-			By("deleting a slave interface")
-			slave, err := netlink.LinkByName(Slave1)
+	When("links are in the initial network namespace at initial state (meaning linksInContainer is false)", func() {
+		BeforeEach(func() {
+			var err error
+			linksInContainer = false
+			podNS, err = testutils.NewNS()
 			Expect(err).NotTo(HaveOccurred())
-			err = netlink.LinkDel(slave)
+			initNS, err = testutils.NewNS()
 			Expect(err).NotTo(HaveOccurred())
-			return nil
+			addLinksInNS(initNS, linkAttrs)
 		})
 
-		Expect(err).NotTo(HaveOccurred())
-
-		By("deleting the bond interface")
-		err = testutils.CmdDel(podNS.Path(),
-			args.ContainerID, "", func() error { return cmdDel(args) })
-		Expect(err).NotTo(HaveOccurred())
-
-	})
-
-	DescribeTable("verifies the plugin returns correct results for supported tested versions", func(version string) {
-		args := &skel.CmdArgs{
-			ContainerID: "dummy",
-			Netns:       podNS.Path(),
-			IfName:      IfName,
-			StdinData:   []byte(fmt.Sprintf(Config, version, ActiveBackupMode)),
-		}
-		By(fmt.Sprintf("creating the plugin with config in version %s", version))
-		r, _, err := testutils.CmdAddWithArgs(args, func() error {
-			return cmdAdd(args)
+		AfterEach(func() {
+			Expect(initNS.Close()).To(Succeed())
+			Expect(testutils.UnmountNS(initNS)).To(Succeed())
 		})
-		Expect(err).NotTo(HaveOccurred())
-		By(fmt.Sprintf("expecting the result version to be %s", version))
-		Expect(r.Version()).To(Equal(version))
-		checkAddReturnResult(&r, IfName)
+		It("verifies a plugin is added and deleted correctly ", func() {
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       podNS.Path(),
+				IfName:      IfName,
+				StdinData:   []byte(fmt.Sprintf(Config, "0.3.1", ActiveBackupMode, strconv.FormatBool(linksInContainer))),
+			}
+			err := initNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				By("creating the plugin")
+				r, _, err := testutils.CmdAddWithArgs(args, func() error {
+					return cmdAdd(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+				By("validating the returned result is correct")
+				checkAddReturnResult(&r, IfName)
 
-		By("deleting plugin")
-		err = testutils.CmdDel(podNS.Path(),
-			args.ContainerID, "", func() error { return cmdDel(args) })
-		Expect(err).NotTo(HaveOccurred())
-	},
-		Entry("When Version is 0.3.0", "0.3.0"),
-		Entry("When Version is 0.3.1", "0.3.1"),
-		Entry("When Version is 0.4.0", "0.4.0"),
-		Entry("When Version is 1.0.0", "1.0.0"),
-		Entry("When Version is 0.2.0", "0.2.0"),
-		Entry("When Version is 0.1.0", "0.1.0"),
-	)
-
-	It("verifies the plugin copes with duplicated macs in balance-tlb mode", func() {
-		args := &skel.CmdArgs{
-			ContainerID: "dummy",
-			Netns:       podNS.Path(),
-			IfName:      IfName,
-			StdinData:   []byte(fmt.Sprintf(Config, "0.3.1", BalanceTlbMode)),
-		}
-
-		err := podNS.Do(func(ns.NetNS) error {
-			defer GinkgoRecover()
-
-			slave1, err := netlink.LinkByName(Slave1)
+				return nil
+			})
 			Expect(err).NotTo(HaveOccurred())
 
-			slave2, err := netlink.LinkByName(Slave2)
+			err = podNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				By("validating the bond interface is configured correctly")
+				link, err := netlink.LinkByName(IfName)
+				Expect(err).NotTo(HaveOccurred())
+				validateBondIFConf(link, 1400, ActiveBackupMode, 100)
+
+				By("validating the bond slaves are configured correctly")
+				validateBondSlavesConf(link, Slaves)
+				return nil
+			})
 			Expect(err).NotTo(HaveOccurred())
 
-			err = netlink.LinkSetHardwareAddr(slave2, slave1.Attrs().HardwareAddr)
+			err = initNS.Do(func(ns.NetNS) error {
+				By("validating the bond interface is deleted correctly")
+				err = testutils.CmdDelWithArgs(args, func() error {
+					return cmdDel(args)
+				})
+				Expect(err).NotTo(HaveOccurred())
+				return nil
+			})
 			Expect(err).NotTo(HaveOccurred())
-			return nil
+
+			By("Checking that links are not in pod namespace")
+
+			err = podNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				for _, slaveName := range Slaves {
+					_, err := netlink.LinkByName(slaveName)
+					Expect(err).To(HaveOccurred())
+				}
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
+			err = initNS.Do(func(ns.NetNS) error {
+				By("Checking that links are in initial namespace")
+				for _, slaveName := range Slaves {
+					_, err := netlink.LinkByName(slaveName)
+					Expect(err).NotTo(HaveOccurred())
+				}
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+
 		})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("creating the plugin")
-		r, _, err := testutils.CmdAddWithArgs(args, func() error {
-			return cmdAdd(args)
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("checking the bond was created")
-		checkAddReturnResult(&r, IfName)
-
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("verifies the plugin handles duplicated macs on delete", func() {
-		var slave1, slave2 netlink.Link
-		var err error
-		args := &skel.CmdArgs{
-			ContainerID: "dummy",
-			Netns:       podNS.Path(),
-			IfName:      IfName,
-			StdinData:   []byte(fmt.Sprintf(Config, "0.3.1", ActiveBackupMode)),
-		}
-
-		err = podNS.Do(func(ns.NetNS) error {
-			defer GinkgoRecover()
-			slave1, err = netlink.LinkByName(Slave1)
-			Expect(err).NotTo(HaveOccurred())
-
-			slave2, err = netlink.LinkByName(Slave2)
-			Expect(err).NotTo(HaveOccurred())
-
-			err = netlink.LinkSetHardwareAddr(slave2, slave1.Attrs().HardwareAddr)
-			Expect(err).NotTo(HaveOccurred())
-			return nil
-		})
-
-		By("creating the plugin")
-		r, _, err := testutils.CmdAddWithArgs(args, func() error {
-			return cmdAdd(args)
-		})
-		Expect(err).NotTo(HaveOccurred())
-
-		By("checking the bond was created")
-		checkAddReturnResult(&r, IfName)
-
-		err = podNS.Do(func(ns.NetNS) error {
-			defer GinkgoRecover()
-			By("duplicating the macs on the slaves")
-			err = netlink.LinkSetHardwareAddr(slave2, slave1.Attrs().HardwareAddr)
-			Expect(err).NotTo(HaveOccurred())
-			return nil
-		})
-		By("deleting the plugin")
-		err = testutils.CmdDel(podNS.Path(),
-			args.ContainerID, "", func() error { return cmdDel(args) })
-		Expect(err).NotTo(HaveOccurred())
-
-		err = podNS.Do(func(ns.NetNS) error {
-			defer GinkgoRecover()
-			By("validating the macs are not duplicated")
-			slave1, err = netlink.LinkByName(Slave1)
-			Expect(err).NotTo(HaveOccurred())
-			slave2, err = netlink.LinkByName(Slave2)
-			Expect(err).NotTo(HaveOccurred())
-			Expect(slave1.Attrs().HardwareAddr.String()).NotTo(Equal(slave2.Attrs().HardwareAddr.String()))
-			return nil
-		})
-		Expect(err).NotTo(HaveOccurred())
 	})
 })
+
+func addLinksInNS(initNS ns.NetNS, links []netlink.LinkAttrs) {
+	for _, link := range links {
+		var err error
+		err = initNS.Do(func(ns.NetNS) error {
+			defer GinkgoRecover()
+			err = netlink.LinkAdd(&netlink.Dummy{
+				LinkAttrs: link,
+			})
+			Expect(err).NotTo(HaveOccurred())
+			return nil
+		})
+		Expect(err).NotTo(HaveOccurred())
+	}
+}
 
 func checkAddReturnResult(r *types.Result, bondIfName string) {
 	switch result := (*r).(type) {
@@ -330,5 +396,22 @@ func checkAddReturnResult(r *types.Result, bondIfName string) {
 		Expect(result.IP6).To(BeNil())
 	default:
 		Fail("Unsupported result type")
+	}
+}
+
+func validateBondIFConf(link netlink.Link, expectedMTU int, expectedMode string, expectedMiimon int) {
+	bond := link.(*netlink.Bond)
+	Expect(bond.Attrs().MTU).To(Equal(expectedMTU))
+	Expect(bond.Mode.String()).To(Equal(expectedMode))
+	Expect(bond.Miimon).To(Equal(expectedMiimon))
+}
+
+func validateBondSlavesConf(link netlink.Link, slaves []string) {
+	bond := link.(*netlink.Bond)
+	for _, slaveName := range slaves {
+		slave, err := netlink.LinkByName(slaveName)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(slave.Attrs().Slave).NotTo(BeNil())
+		Expect(slave.Attrs().MasterIndex).To(Equal(bond.Attrs().Index))
 	}
 }

--- a/bond/util/validation.go
+++ b/bond/util/validation.go
@@ -7,13 +7,19 @@ import (
 	"github.com/vishvananda/netlink"
 )
 
+const (
+	standardEthernetMTU = 1500
+	defaultMTU          = standardEthernetMTU
+	minMtuIpv4Packet    = 68
+)
+
 func ValidateMTU(slaveLinks []netlink.Link, mtu int) error {
 	// if not specified set MTU to default
 	if mtu == 0 {
-		mtu = 1500
+		mtu = defaultMTU
 	}
 
-	if mtu < 68 {
+	if mtu < minMtuIpv4Packet {
 		return fmt.Errorf("Invalid bond MTU value (%+v), should be 68 or bigger", mtu)
 	}
 	netHandle, err := netlink.NewHandle()


### PR DESCRIPTION
This PR is about increasing test coverage for the Bond CNI.
It consists of 3 main changes to the Bond CNI tests, each of them in a separate commit to maintain a clean history.
The 3 changes are:

- Remove Redundancy in tests
- Add Test for linksInContainer = false 
- Create Test Case Where Bond MTU is Greater than Links MTU

i will also include a  detailed explanation of each of them:

**Remove Redundancy in tests**
 
Includes:
- Create a separate function for the test scenario "validating the correctness of the returned result of the add command," which occurs in multiple test cases. This function is used multiple times within the test suite, reducing code duplication.

- Combine all tests that test the plugin returns the correct result matching a specific version in the add command result into a single test. This test should run with various parameters. Previously, there were separate tests for each version, resulting in similar code duplication.

- Modify all tests to execute the plugin creation and deletion commands from the host namespace instead of the pod namespace. This adjustment will better simulate the real flow of events.

**Add Test for linksInContainer = false** 

introduces a new test case that tests the code flow when the linksInContainer parameter is set to false, indicating that links start in the host namespace instead of the pod namespace. This scenario requires a different setup than usual, involving the addition of dummy links to the host namespace rather than the pod namespace.

Includes:

- Created a generic function (addLinksInNS) responsible for adding links during namespace setup for each test. This function is needed for the new test, where dummy links are added to the host namespace.

- Implemented a function (delLinksInNS) to delete the links created in the namespace, ensuring that dummy links in the host namespace are removed after the test.

- Added an option to modify the linksInContainer setting in the string config used across all tests. This change allows each test to set the linksInContainer option to true or false as needed.

- Introduced a test case that verifies the correct addition and deletion of the plugin while links are active in the host network namespace. To avoid redundancy, new functions (validateBondIFConf, validateBondSlavesConf) were added.

- Included a missing netNs.Close() statement in the bond code's setLinksinNetNs function to properly close the pod namespace.

- Also added curnetNs.Set() to the setLinksinNetNs function. This change ensures the correct transfer of the namespace back to the current namespace after function execution.

**Create Test Case Where Bond MTU is Greater than Links MTU**

 Introduces a new test case in which the bond's MTU is larger than the MTU of its links. The test verifies whether an error is raised when the bond's MTU exceeds the MTU of its links.

Includes:

- Added an option to modify the MTU setting in the string config used across all tests. This change allows each test to set the MTU option to the desired value.

- Created a constant for the values used in the MTU validation function, thereby improving code readability by avoiding the use of "magic numbers."
