### PR TITLE
Publish container image

### DIFF
--- a/.github/workflows/image-build.yml
+++ b/.github/workflows/image-build.yml
@@ -1,0 +1,20 @@
+name: Image build
+on: [pull_request]
+jobs:
+  build:
+    name: Image plugin
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build container image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: false
+          tags: ghcr.io/${{ github.repository }}:latest
+          file: images/Dockerfile

--- a/.github/workflows/image-push-master.yml
+++ b/.github/workflows/image-push-master.yml
@@ -1,0 +1,36 @@
+name: Image push for master
+on:
+  push:
+    branches:
+      - master
+env:
+  image-push-owner: 'k8snetworkplumbingwg'
+jobs:
+
+  push:
+    name: Image push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository_owner == env.image-push-owner }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Push container image
+        if: ${{ github.repository_owner == env.image-push-owner }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:latest
+          file: images/Dockerfile

--- a/.github/workflows/image-push-release.yml
+++ b/.github/workflows/image-push-release.yml
@@ -1,0 +1,44 @@
+name: Image push release
+on:
+  push:
+    tags:
+      - v*
+env:
+  image-push-owner: 'k8snetworkplumbingwg'
+jobs:
+  push:
+    name: Image push
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out code into the Go module directory
+        uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        if: ${{ github.repository_owner == env.image-push-owner }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Docker meta
+        id: docker_meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ghcr.io/${{ github.repository }}
+          flavor: |
+            latest=false
+
+      - name: Push container image
+        if: ${{ github.repository_owner == env.image-push-owner }}
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: |
+            ghcr.io/${{ github.repository }}:stable
+            ${{ steps.docker_meta.outputs.tags }}
+          file: images/Dockerfile

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,0 +1,15 @@
+# This Dockerfile is used to build the image available on DockerHub
+FROM docker.io/golang:1.23 AS build
+
+WORKDIR /usr/src/bond-cni
+COPY . .
+RUN make build-bin
+
+FROM docker.io/alpine:latest
+LABEL org.opencontainers.image.source=https://github.com/k8snetworkplumbingwg/bond-cni
+WORKDIR /
+COPY --from=build /usr/src/bond-cni/bin .
+COPY LICENSE .
+COPY images/entrypoint.sh .
+
+CMD ["/entrypoint.sh"]

--- a/images/entrypoint.sh
+++ b/images/entrypoint.sh
@@ -1,0 +1,15 @@
+#!/bin/sh
+
+set -u -e -x
+
+CNI_BIN_DIR=${CNI_BIN_DIR:-"/host/opt/cni/bin/"}
+
+cp -f /bond $CNI_BIN_DIR
+
+# Unless told otherwise, sleep forever.
+# This prevents Kubernetes from restarting the pod repeatedly.
+should_sleep=${SLEEP:-"true"}
+echo "Done configuring CNI.  Sleep=$should_sleep"
+while [ "$should_sleep" == "true"  ]; do
+    sleep 1000000000000
+done

--- a/manifests/bond-cni.yaml
+++ b/manifests/bond-cni.yaml
@@ -1,0 +1,42 @@
+apiVersion: apps/v1
+kind: DaemonSet
+metadata:
+  name: bond-cni
+  labels:
+    tier: node
+    app: bond-cni
+spec:
+  selector:
+    matchLabels:
+      app: bond-cni
+  updateStrategy:
+    type: RollingUpdate
+    rollingUpdate:
+      maxUnavailable: 10%
+  template:
+    metadata:
+      labels:
+        tier: node
+        app: bond-cni
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+        kubernetes.io/os: linux
+      tolerations:
+      - key: node-role.kubernetes.io/master
+        operator: Exists
+        effect: NoSchedule
+      containers:
+      - name: bond-cni-plugin
+        image: ghcr.io/k8snetworkplumbingwg/bond-cni:latest
+        resources:
+          requests:
+            cpu: "10m"
+            memory: "15Mi"
+        volumeMounts:
+        - name: cnibin
+          mountPath: /host/opt/cni/bin/
+      volumes:
+        - name: cnibin
+          hostPath:
+            path: /opt/cni/bin/


### PR DESCRIPTION
- Build plugin image
Add Dockerfile and related entrypoint.sh to build the binary and copy
it to the host.

- Build and publish images in CI
Add GitHub configuration to publish the docker image with the plugin binary

- Deployment file
With this configuration, `bond` CNI plugin can be deployed via:
```
kubectl apply -f https://raw.githubusercontent.com/k8snetworkplumbingwg/bond-cni/master/manifests/bond.yml
```

Fixes #104 