### PR TITLE
Add all_slaves_active option

### DIFF
--- a/README.md
+++ b/README.md
@@ -54,6 +54,7 @@ Given the following network configuration:
 		"miimon": "100",
 		"mtu": 1500,
                 "failOverMac": 1,
+                "allSlavesActive": 0,
 		"links": [
             {
 				"name": "ens3f2"


### PR DESCRIPTION
This parameter is needed when one wants packets to be duplicated in the active link when these are received on inactive ports