### PR TITLE
Add tlb_dynamic_lb and xmit_hash_policy config parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ The binary should be placed at /opt/cni/bin on all nodes on which bonding will t
 - ipam (dictionary, required): IPAM configuration to be used for this network
 - allSlavesActive (int, optional): specifies that duplicate frames received on inactive ports should be dropped (0) or delivered (1). Default is 0.
 - tlbDynamicLb (int, optional): specifies if dynamic shuffling of flows is enabled in tlb mode. Default is 1.
+- xmitHashPolicy (string, optional): selects the transmit hash policy to use for slave selection in balance-xor, 802.3ad, and tlb modes.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ The binary should be placed at /opt/cni/bin on all nodes on which bonding will t
 - linksInContainer(boolean, optional): specifies if slave links are in container to start. Default is false i.e. look for interfaces on host before bonding.
 - links (dictionary, required): master interface names
 - ipam (dictionary, required): IPAM configuration to be used for this network
+- allSlavesActive (int, optional): specifies that duplicate frames received on inactive ports should be dropped (0) or delivered (1). Default is 0.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ The binary should be placed at /opt/cni/bin on all nodes on which bonding will t
 - links (dictionary, required): master interface names
 - ipam (dictionary, required): IPAM configuration to be used for this network
 - allSlavesActive (int, optional): specifies that duplicate frames received on inactive ports should be dropped (0) or delivered (1). Default is 0.
+- tlbDynamicLb (int, optional): specifies if dynamic shuffling of flows is enabled in tlb mode. Default is 1.
 
 ## Usage
 

--- a/bond/bond.go
+++ b/bond/bond.go
@@ -70,6 +70,10 @@ func loadConfigFile(bytes []byte) (*bondingConfig, string, error) {
 		return nil, "", fmt.Errorf("bond is not a suitable IPAM type")
 	}
 
+	if bondConf.FailOverMac < 0 || bondConf.FailOverMac > 2 {
+		return nil, "", fmt.Errorf("FailOverMac mode should be 0, 1 or 2 actual: %+v", bondConf.FailOverMac)
+	}
+
 	if bondConf.AllSlavesActive != nil && *bondConf.AllSlavesActive != 0 && *bondConf.AllSlavesActive != 1 {
 		return nil, "", fmt.Errorf("allSlavesActive should be 0 or 1, actual: %+v", *bondConf.AllSlavesActive)
 	}
@@ -306,9 +310,6 @@ func createBond(bondName string, bondConf *bondingConfig, nspath string, ns ns.N
 		return nil, err
 	}
 
-	if bondConf.FailOverMac < 0 || bondConf.FailOverMac > 2 {
-		return nil, fmt.Errorf("FailOverMac mode should be 0, 1 or 2 actual: %+v", bondConf.FailOverMac)
-	}
 	bondLinkObj, err := createBondedLink(bondName, bondConf, netNsHandle)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create bonded link (%+v), error: %+v", bondName, err)

--- a/bond/bond_test.go
+++ b/bond/bond_test.go
@@ -484,6 +484,92 @@ var _ = Describe("bond plugin", func() {
 		)
 	})
 
+	When("tlb_dynamic_lb is added to the config", func() {
+		var config string
+
+		BeforeEach(func() {
+			var err error
+
+			config = `{
+			"name": "bond",
+			"type": "bond",
+			"cniVersion": "0.3.1",
+			"mode": "%s",
+			"failOverMac": 1,
+			"linksInContainer": true,
+			"miimon": "100",
+			"mtu": 1400,
+			"links": [
+				{"name": "net1"},
+				{"name": "net2"}
+			],
+            "tlbDynamicLb": %d
+		}`
+
+			linksInContainer = true
+			linkAttrs := []netlink.LinkAttrs{
+				{Name: Slave1},
+				{Name: Slave2},
+			}
+			podNS, err = testutils.NewNS()
+			Expect(err).NotTo(HaveOccurred())
+			addLinksInNS(podNS, linkAttrs)
+		})
+
+		DescribeTable("Verify all tlb_dynamic_lb is properly set", func(tlbDynamicLb int) {
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       podNS.Path(),
+				IfName:      IfName,
+				StdinData:   []byte(fmt.Sprintf(config, BalanceTlbMode, tlbDynamicLb)),
+			}
+			By("creating the plugin")
+			r, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+
+			if tlbDynamicLb != 0 && tlbDynamicLb != 1 {
+				Expect(err).To(HaveOccurred())
+				return
+			}
+			Expect(err).NotTo(HaveOccurred())
+
+			By("validating the returned result is correct")
+			checkAddReturnResult(&r, IfName)
+
+			Expect(err).To(Not(HaveOccurred()))
+
+			err = podNS.Do(func(ns.NetNS) error {
+				defer GinkgoRecover()
+				By("validating the bond interface is configured correctly")
+				link, err := netlink.LinkByName(IfName)
+				Expect(err).NotTo(HaveOccurred())
+
+				Expect(link.(*netlink.Bond).TlbDynamicLb).To(Equal(tlbDynamicLb))
+				return nil
+			})
+			Expect(err).NotTo(HaveOccurred())
+		},
+			Entry("tlb_dynamic_lb is disabled", 0),
+			Entry("tlb_dynamic_lb is enabled", 1),
+			Entry("tlb_dynamic_lb value is invalid", 2),
+		)
+
+		It("should fail if mode is not balance-tlb", func() {
+			args := &skel.CmdArgs{
+				ContainerID: "dummy",
+				Netns:       podNS.Path(),
+				IfName:      IfName,
+				StdinData:   []byte(fmt.Sprintf(config, ActiveBackupMode, 0)),
+			}
+			By("creating the plugin")
+			_, _, err := testutils.CmdAddWithArgs(args, func() error {
+				return cmdAdd(args)
+			})
+			Expect(err).To(HaveOccurred())
+		})
+	})
+
 	When("links are in the initial network namespace at initial state (meaning linksInContainer is false)", func() {
 		var config string
 		BeforeEach(func() {

--- a/bond/bond_test.go
+++ b/bond/bond_test.go
@@ -461,6 +461,7 @@ var _ = Describe("bond plugin", func() {
 				Expect(err).To(HaveOccurred())
 				return
 			}
+			Expect(err).NotTo(HaveOccurred())
 
 			By("validating the returned result is correct")
 			checkAddReturnResult(&r, IfName)


### PR DESCRIPTION
This PR adds tlb_dynamic_lb and xmit_hash_policy parameters. It also adds a missing error check for all_slaves_active test and move the fail_over_mac parameter check together with other validations.