### PR TITLE
Bump Kubernetes target to 1.36.2 and Go to 1.26

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -38,7 +38,7 @@ jobs:
     needs: build
     name: unit-test
     container:
-      image: golang:1.25
+      image: golang:1.26
       options: --privileged
     steps:
       - uses: actions/checkout@v7

--- a/Makefile
+++ b/Makefile
@@ -15,5 +15,5 @@ unittest:
 		-v $(CURDIR):/workspace \
 		-v $(CURDIR)/.gomodcache:/go/pkg/mod \
 		-w /workspace \
-		golang:1.25 \
+		golang:1.26 \
 		go test -race -covermode=atomic -coverprofile=profile.out ./... $(ARG)

--- a/clab/kind-cluster.yaml
+++ b/clab/kind-cluster.yaml
@@ -2,4 +2,6 @@ kind: Cluster
 apiVersion: kind.x-k8s.io/v1alpha4
 nodes:
   - role: control-plane
+    image: kindest/node:v1.36.1
   - role: worker
+    image: kindest/node:v1.36.1

--- a/go.mod
+++ b/go.mod
@@ -1,8 +1,6 @@
 module github.com/intel/bond-cni
 
-go 1.25.0
-
-toolchain go1.25.3
+go 1.26.0
 
 require (
 	github.com/containernetworking/cni v1.3.0

--- a/images/Dockerfile
+++ b/images/Dockerfile
@@ -1,5 +1,5 @@
 # This Dockerfile is used to build the image available on DockerHub
-FROM docker.io/golang:1.25 AS build
+FROM docker.io/golang:1.26 AS build
 
 WORKDIR /usr/src/bond-cni
 COPY . .


### PR DESCRIPTION
Kubernetes v1.36.2 is built with Go 1.26, so align this repo's Go module version, build images, and CI test container with that baseline.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated the project’s Go toolchain to version 1.26.
  * Updated build and test environments to use Go 1.26.
  * Pinned cluster nodes to the same container image version for more consistent deployments.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->